### PR TITLE
Make batch size parameter configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ Configs for logging is defined at config/logging.php. You should add
         'secret' => env('CLOUDWATCH_LOG_SECRET', ''),
         'stream_name' => env('CLOUDWATCH_LOG_STREAM_NAME', 'laravel_app'),
         'retention' => env('CLOUDWATCH_LOG_RETENTION_DAYS', 14),
+        'batch_size' => env('CLOUDWATCH_LOG_BATCH_SIZE', 10000),
         'group_name' => env('CLOUDWATCH_LOG_GROUP_NAME', 'laravel_app'),
         'version' => env('CLOUDWATCH_LOG_VERSION', 'latest'),
     ],

--- a/src/Providers/CloudWatchServiceProvider.php
+++ b/src/Providers/CloudWatchServiceProvider.php
@@ -39,7 +39,8 @@ class CloudWatchServiceProvider extends ServiceProvider
         $streamName = $loggingConfig['stream_name'];
         $retentionDays = $loggingConfig['retention'];
         $groupName = $loggingConfig['group_name'];
-        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, 10000);
+        $batchSize = isset($loggingConfig['batch_size']) ? $loggingConfig['batch_size'] : 10000;
+        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, $batchSize);
         $logger = new Logger($loggingConfig['name']);
         $formatter = new LineFormatter('%channel%: %level_name%: %message% %context% %extra%', null, false, true);
         $logHandler->setFormatter($formatter);


### PR DESCRIPTION
Adds a configuration parameter so batch size can be specified to `cwh`

This is useful for long-running applications, or laravel works running as `daemon` who don't `close` the logger or reboot the framework often.