### PR TITLE
Allow user to determine credentials scheme

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -4,8 +4,10 @@ return [
     'cloudwatch' => [
         'name' => env('CLOUDWATCH_LOG_NAME', ''),
         'region' => env('CLOUDWATCH_LOG_REGION', ''),
-        'key' => env('CLOUDWATCH_LOG_KEY', ''),
-        'secret' => env('CLOUDWATCH_LOG_SECRET', ''),
+        'credentials' => [
+	        'key' => env('CLOUDWATCH_LOG_KEY', ''),
+	        'secret' => env('CLOUDWATCH_LOG_SECRET', ''),
+        ],
         'stream_name' => env('CLOUDWATCH_LOG_STREAM_NAME', 'laravel_app'),
         'retention' => env('CLOUDWATCH_LOG_RETENTION_DAYS', 14),
         'group_name' => env('CLOUDWATCH_LOG_GROUP_NAME', 'laravel_app'),

--- a/src/Providers/CloudWatchServiceProvider.php
+++ b/src/Providers/CloudWatchServiceProvider.php
@@ -94,17 +94,14 @@ class CloudWatchServiceProvider extends ServiceProvider
 
         $cloudWatchConfigs = $loggingConfig['cloudwatch'];
 
-        if (!isset($cloudWatchConfigs['key'], $cloudWatchConfigs['secret'], $cloudWatchConfigs['region'])) {
-            throw new IncompleteCloudWatchConfig('One or Multiple Configuration Missing for Cloudwatch Log: key, secret and/or region');
+        if (!isset($cloudWatchConfigs['region'])) {
+            throw new IncompleteCloudWatchConfig('Missing region key-value');
         }
 
         return $awsCredentials = [
             'region' => $cloudWatchConfigs['region'],
             'version' => $cloudWatchConfigs['version'],
-            'credentials' => [
-                'key' => $cloudWatchConfigs['key'],
-                'secret' => $cloudWatchConfigs['secret'],
-            ],
+            'credentials' => $cloudWatchConfigs['credentials'],
         ];
     }
 }


### PR DESCRIPTION
Default to environment variables but allow user to use own scheme (IAM role credentials, etc.)

As an example I am using `DoctrineCacheAdapter` as the value for `credentials` so that, on my EC2 instance, AWS uses the default provider and uses the IAM for the instance so I don't have to specify key/secret in the environment variables.