### PR TITLE
Change access level of getCredentials to protected to allow overriding

### DIFF
--- a/src/Providers/CloudWatchServiceProvider.php
+++ b/src/Providers/CloudWatchServiceProvider.php
@@ -93,7 +93,7 @@ class CloudWatchServiceProvider extends ServiceProvider
      *
      * @return array
      */
-    private function getCredentials()
+    protected function getCredentials()
     {
         $loggingConfig = config('logging.channels');
 


### PR DESCRIPTION
I extended the provider in our project and realized I can't use it when `getCredentials` has an access level of `private`. Needs to be `protected` so child classes can use it.