### PR TITLE
Fix missing driver key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ Config for logging is defined at `config/logging.php`. Add `cloudwatch` to the `
 ```
 'channels' =>  [
     'cloudwatch' => [
+            'driver' => 'custom',
             'name' => env('CLOUDWATCH_LOG_NAME', ''),
             'region' => env('CLOUDWATCH_LOG_REGION', ''),
             'credentials' => [


### PR DESCRIPTION
Needed to setup a 'driver' => 'custom' key in the cloudwatch channel array to work