### PR TITLE
Allow stream_name configuration value to be a callable

### DIFF
--- a/src/Providers/CloudWatchServiceProvider.php
+++ b/src/Providers/CloudWatchServiceProvider.php
@@ -46,7 +46,7 @@ class CloudWatchServiceProvider extends ServiceProvider
         $cwClient = new CloudWatchLogsClient($this->getCredentials());
         $loggingConfig = $this->app->make('config')->get('logging.channels.cloudwatch');
 
-        $streamName = $loggingConfig['stream_name'];
+        $streamName = $this->resolveStreamName($loggingConfig['stream_name']);
         $retentionDays = $loggingConfig['retention'];
         $groupName = $loggingConfig['group_name'];
         $batchSize = isset($loggingConfig['batch_size']) ? $loggingConfig['batch_size'] : 10000;
@@ -59,6 +59,15 @@ class CloudWatchServiceProvider extends ServiceProvider
         $logger->pushHandler($logHandler);
 
         return $logger;
+    }
+
+    protected function resolveStreamName($configuredValue)
+    {
+        if (is_callable($configuredValue)) {
+            return call_user_func($configuredValue);
+        }
+
+        return $configuredValue;
     }
 
     /**

--- a/tests/Support/CallableStreamNameGenerator.php
+++ b/tests/Support/CallableStreamNameGenerator.php
@@ -1,0 +1,10 @@
+<?php
+namespace Tests\Support;
+
+class CallableStreamNameGenerator
+{
+    public static function generateStreamName()
+    {
+        return 'generated-stream-name';
+    }
+}


### PR DESCRIPTION
This implements a helpful feature for me and my team.  The requirements:  

1. Have two different Cloudwatch log streams, one for web traffic and one for background worker traffic
2. Have `config:cache` executed on production

I had something like `'stream_name' => app()->runningInConsole() ? 'laravel-worker' : 'laravel'` in the config, but `cache:config` would process this and always end up as laravel-worker, even for web traffic.

This feature would let you do things like `'stream_name' => [CallableStreamNameGenerator::class, 'generateStreamName']` to fetch the stream name at run time.