### PR TITLE
Dev/add create group opt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,10 @@ And set the `LOG_CHANNEL` in your environment variable to `cloudwatch`.
 
 If the role of your AWS EC2 instance has access to Cloudwatch logs, `CLOUDWATCH_LOG_KEY` and `CLOUDWATCH_LOG_SECRET` need not be defined in your `.env` file.
 
+### AWS IAM permissions
+
+The needed permissions can be found [here](https://github.com/maxbanton/cwh#aws-iam-needed-permissions).
+
 ### Contribution
 
 I have added a `pre-commit` hook to run `php-cs-fixer` whenever you make a commit. To enable this run `sh hooks.sh`.

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,8 @@ Config for logging is defined at `config/logging.php`. Add `cloudwatch` to the `
             'group_name' => env('CLOUDWATCH_LOG_GROUP_NAME', 'laravel_app'),
             'version' => env('CLOUDWATCH_LOG_VERSION', 'latest'),
             'formatter' => \Monolog\Formatter\JsonFormatter::class,       
-            'batch_size' => env('CLOUDWATCH_LOG_BATCH_SIZE', 10000),    
+            'batch_size' => env('CLOUDWATCH_LOG_BATCH_SIZE', 10000),
+            'create_group' => env('CLOUDWATCH_CREATE_GROUP', true)
             'via' => \Pagevamp\Logger::class,
         ],
 ]

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,6 +2,7 @@
 
 namespace Pagevamp;
 
+use Monolog\Logger as MonoLogger;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\LineFormatter;
@@ -29,9 +30,10 @@ class Logger
         $streamName = $loggingConfig['stream_name'];
         $retentionDays = $loggingConfig['retention'];
         $groupName = $loggingConfig['group_name'];
+        $createGroup = $loggingConfig['create_group'];
         $batchSize = isset($loggingConfig['batch_size']) ? $loggingConfig['batch_size'] : 10000;
 
-        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, $batchSize);
+        $logHandler = new CloudWatch($cwClient, $groupName, $streamName, $retentionDays, $batchSize, [], MonoLogger::DEBUG, true, $createGroup);
         $logger = new \Monolog\Logger($loggingConfig['name']);
 
         $formatter = $this->resolveFormatter($loggingConfig);


### PR DESCRIPTION
This is a small update that passes through a new `created_config` option to the underlying logger.

This is needed in order to tamp down iam permissions if you're following best-practices.