### PR TITLE
temporary use another cloudwatch logs handler library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "maxbanton/cwh": "^1.1.14 || ^2.0",
+        "phpnexus/cwh": "^1.1.14 || ^2.0 || ^3.0.0",
         "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0"
     },
     "require-dev": {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -3,7 +3,7 @@
 namespace Pagevamp;
 
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
-use Maxbanton\Cwh\Handler\CloudWatch;
+use Phpnexus\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\LineFormatter;
 use Pagevamp\Exceptions\IncompleteCloudWatchConfig;
 


### PR DESCRIPTION
Since package [maxbanton/cwh](https://github.com/maxbanton/cwh) hasn't been maintained for a while according to [#116](https://github.com/maxbanton/cwh/issues/116), people inherited it and created [new packge](https://github.com/phpnexus/cwh/releases/tag/v3.0.0) to deal with it.

This merge request is created to fix [#41 ](https://github.com/pagevamp/laravel-cloudwatch-logs/issues/41)