### PR TITLE
Support Laravel 12 and setup CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        laravel:
+          - "^10.0"
+          - "^11.0"
+          - "^12.0"
+        exclude:
+          - laravel: "^11.0"
+            php: "8.1"
+          - laravel: "^12.0"
+            php: "8.1"
+
+    name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }} / ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP, with composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --ansi
+
+      - name: Install Composer dependencies
+        run: composer update --no-interaction --no-progress --ansi
+
+      - name: Run Unit tests
+        run: vendor/bin/phpunit --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.phpunit.result.cache
 vendor

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "phpnexus/cwh": "^1.1.14 || ^2.0 || ^3.0.0",
-        "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0 || ^11.0"
+        "illuminate/support": "^5.1 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12 || ^2.16|^3.14",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -19,7 +19,7 @@ class LoggerTest extends TestCase
     {
         $cloudwatchConfigs = [
             'name' => '',
-            'region' => '',
+            'region' => 'us-east-1',
             'credentials' => [
                 'key' => '',
                 'secret' => '',
@@ -70,7 +70,7 @@ class LoggerTest extends TestCase
     {
         $cloudwatchConfigs = [
             'name' => '',
-            'region' => '',
+            'region' => 'us-east-1',
             'credentials' => [
                 'key' => '',
                 'secret' => '',
@@ -121,7 +121,7 @@ class LoggerTest extends TestCase
     {
         $cloudwatchConfigs = [
             'name' => '',
-            'region' => '',
+            'region' => 'us-east-1',
             'credentials' => [
                 'key' => '',
                 'secret' => '',
@@ -171,7 +171,7 @@ class LoggerTest extends TestCase
     {
         $cloudwatchConfigs = [
             'name' => '',
-            'region' => '',
+            'region' => 'us-east-1',
             'credentials' => [
                 'key' => '',
                 'secret' => '',
@@ -224,7 +224,7 @@ class LoggerTest extends TestCase
     {
         $cloudwatchConfigs = [
             'name' => '',
-            'region' => '',
+            'region' => 'us-east-1',
             'credentials' => [
                 'key' => '',
                 'secret' => '',


### PR DESCRIPTION
* Added support for Laravel 12
* Fixed issue with tests not passing with latest AWS SDK
* Set up CI with multiple combinations of Laravel and PHP versions:
  * PHP: 8.1, 8.2, 8.3, 8.4
  * Laravel: 10, 11, 12